### PR TITLE
[✨feat]: button 컴포넌트 구현

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+interface ButtonProps {
+  label: string;
+  onClick: () => void;
+  bgColor?: string;
+  textColor?: string;
+  padding?: string; // 여백
+  rounded?: string; // 경계선 라운딩
+  disabled?: boolean; // 비활성화 여부
+  className?: string; // 추가적인 Tailwind CSS 클래스
+  type?: 'submit' | 'reset' | 'button';
+}
+
+const Button = ({
+  label,
+  onClick,
+  bgColor = 'bg-primary',
+  textColor = 'text-white',
+  padding = 'py-3 px-4',
+  rounded = 'rounded-md',
+  disabled = false,
+  className = '',
+  type = 'button',
+}: ButtonProps) => {
+  const disabledStyles = 'bg-[#C6BBE1] text-white cursor-not-allowed';
+
+  return (
+    <button
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      type={type}
+      className={`${disabled ? disabledStyles : `${bgColor} ${textColor}`} ${padding} ${rounded} ${className} flex justify-center items-center`}>
+      {label}
+    </button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
## 🌱 만들고자 하는 기능
![image](https://github.com/user-attachments/assets/11621eb0-be63-490a-b6e1-c5660c72f1bd)

## 🌱 구현 내용
재사용 가능하고 커스터마이징이 가능한 버튼 컴포넌트를 구현했습니다
bgColor, textColor, padding, rounded 등의 props를 통해 버튼의 스타일을 유연하게 변경할 수 있습니다
비활성화 상태에서 고유한 스타일(bg-[#C6BBE1], cursor-not-allowed)이 적용됩니다
submit, reset, button 타입을 props로 관리할 수 있습니다

## ✅ check list
- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
