### PR TITLE
[✨feat]: 공개용 프로필 페이지 구현

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,10 +1,9 @@
 'use client';
+import Image from 'next/image';
 import { useForm } from 'react-hook-form';
 
-import Input from '@/components/common/Input';
-import Image from 'next/image';
-import hand from '../../../public/images/hand.png';
 import Button from '@/components/common/Button';
+import Input from '@/components/common/Input';
 
 interface FormDatas {
   email: string;

--- a/src/app/public-profile/page.tsx
+++ b/src/app/public-profile/page.tsx
@@ -64,11 +64,11 @@ const PublicProfile = () => {
                   xmlns="http://www.w3.org/2000/svg"
                   className="cursor-pointer">
                   <path
-                    fill-rule="evenodd"
-                    clip-rule="evenodd"
+                    fillRule="evenodd"
+                    clipRule="evenodd"
                     d="M15.5303 3.96967C15.8232 4.26256 15.8232 4.73744 15.5303 5.03033L8.56066 12L15.5303 18.9697C15.8232 19.2626 15.8232 19.7374 15.5303 20.0303C15.2374 20.3232 14.7626 20.3232 14.4697 20.0303L6.96967 12.5303C6.67678 12.2374 6.67678 11.7626 6.96967 11.4697L14.4697 3.96967C14.7626 3.67678 15.2374 3.67678 15.5303 3.96967Z"
                     fill="black"
-                    fill-opacity="0.8"
+                    fillOpacity="0.8"
                   />
                 </svg>
               </button>

--- a/src/app/public-profile/page.tsx
+++ b/src/app/public-profile/page.tsx
@@ -6,45 +6,40 @@ import StudyExperienceCard from '@/components/common/StudyExperienceCard';
 import TagList from '@/components/common/TagList';
 
 const PublicProfile = () => {
-  const StudyExperienceDatas = [
-    {
-      title: '피그마 초급 실습 스터디',
-      score: 80,
+  // const { id } = useParams();
+
+  const profiles = {
+    '1': {
+      name: '제이크',
+      job: '기획자',
+      totalStudy: 8,
       attendance: 98,
+      text: '안녕하세요. 개발 관련 글을 꾸준히 쓰고 싶은데 의지가 부족해 스터디 버디들을 구하고 싶습니다 화이팅',
+      StudyExperienceDatas: [
+        {
+          title: '피그마 초급 실습 스터디',
+          score: 80,
+          attendance: 98,
+        },
+        {
+          title: '디자인 기획 실습 스터디',
+          score: 80,
+          attendance: 100,
+        },
+      ],
+      StudyPurposeDatas: [
+        { purpose: '툴 능력 향상' },
+        { purpose: '해당 분야의 네트워킹 확장' },
+      ],
+      StudyStyleDatas: [
+        { style: '손이 빠름' },
+        { style: '열정적' },
+        { style: '동기부여가 필요한' },
+      ],
+      StudyPeriodDatas: [{ period: '1개월 ~ 3개월' }],
     },
-
-    {
-      title: '디자인 기획 실습 스터디',
-      score: 80,
-      attendance: 100,
-    },
-  ];
-  const StudyPurposeDatas = [
-    {
-      purpose: '툴 능력 향상',
-    },
-    {
-      purpose: '해당 분야의 네트워킹 확장',
-    },
-  ];
-
-  const StudyStyleDatas = [
-    {
-      style: '손이 빠름',
-    },
-    {
-      style: '열정적',
-    },
-    {
-      style: '동기부여가 필요한',
-    },
-  ];
-
-  const StudyPeriodDatas = [
-    {
-      period: '1개월 ~ 3개월',
-    },
-  ];
+  };
+  // const profile = profiles[id as keyof typeof profiles];
 
   const handleLeftClick = () => {};
   const handleAccept = () => {};
@@ -80,22 +75,21 @@ const PublicProfile = () => {
             </div>
           </div>
           <div className="text-center">
-            <div className="font-semibold text-[1.25rem]">제이크</div>
-            <p className=" text-[0.875rem] ">기획자</p>
+            <div className="font-semibold text-[1.25rem]">
+              {profiles[1].name}
+            </div>
+            <p className=" text-[0.875rem] ">{profiles[1].job}</p>
           </div>
 
           <div>
             <div className="font-bold">한줄 자기소개</div>
-            <p>
-              안녕하세요. 개발 관련 글을 꾸준히 쓰고 싶은데 의지가 부족해 스터디
-              버디들을 구하고 싶습니다 화이팅
-            </p>
+            <p>{profiles[1].text}</p>
             <hr className="w-full border-[0.188rem] border-[#E9E9E9] mt-5 mb-5" />
             <div className="flex flex-col space-y-5">
               <div>
                 <p className=" text-base font-bold">스터디 목적</p>
                 <div className="flex flex-row gap-2">
-                  {StudyPurposeDatas.map((purpose, index) => (
+                  {profiles[1].StudyPurposeDatas.map((purpose, index) => (
                     <TagList key={index} tagData={[purpose.purpose]} disabled />
                   ))}
                 </div>
@@ -103,7 +97,7 @@ const PublicProfile = () => {
               <div>
                 <p className="text-base font-bold">스타일</p>
                 <div className="flex flex-row gap-2">
-                  {StudyStyleDatas.map((style, index) => (
+                  {profiles[1].StudyStyleDatas.map((style, index) => (
                     <TagList key={index} tagData={[style.style]} disabled />
                   ))}
                 </div>
@@ -112,7 +106,7 @@ const PublicProfile = () => {
               <div>
                 <p className="text-base font-bold">스터디 기간</p>
                 <div className="flex flex-row gap-2">
-                  {StudyPeriodDatas.map((period, index) => (
+                  {profiles[1].StudyPeriodDatas.map((period, index) => (
                     <TagList key={index} tagData={[period.period]} disabled />
                   ))}
                 </div>
@@ -124,7 +118,7 @@ const PublicProfile = () => {
                 </p>
 
                 <div className="flex flex-row p-5 gap-3">
-                  {StudyExperienceDatas.map((study, index) => (
+                  {profiles[1].StudyExperienceDatas.map((study, index) => (
                     <StudyExperienceCard
                       key={index}
                       title={study.title}

--- a/src/app/public-profile/page.tsx
+++ b/src/app/public-profile/page.tsx
@@ -1,17 +1,37 @@
 'use client';
 
+import Avartar from '@/components/common/Avatar';
 import Button from '@/components/common/Button';
+import StudyExperienceCard from '@/components/common/StudyExperienceCard';
 
 const handleAccept = () => {};
 
 const PublicProfile = () => {
+  const StudyExperienceDatas = [
+    {
+      title: '피그마 초급 실습 스터디',
+      score: 80,
+      attendance: 98,
+    },
+
+    {
+      title: '디자인 기획 실습 스터디',
+      score: 80,
+      attendance: 100,
+    },
+    {
+      title: '피그마 중급 스터디',
+      score: 70,
+      attendance: 90,
+    },
+  ];
   return (
     <>
       <div className="flex justify-center items-center  h-screen">
         <div className="flex items-center flex-col w-[21.438rem] space-y-5">
           <div className="text-center space-y-5 ">
-            <div className="font-bold text-[1.125rem]  ">오픈 프로필</div>
-            <img src="/images/profile.png" alt="프로필 " />
+            <div className="font-bold text-[1.125rem]">오픈 프로필</div>
+            <Avartar size={100} />
           </div>
           <div>
             <div className="font-semibold text-[1.25rem]">이름</div>
@@ -24,15 +44,33 @@ const PublicProfile = () => {
               안녕하세요. 개발 관련 글을 꾸준히 쓰고 싶은데 의지가 부족해 스터디
               버디들을 구하고 싶습니다 화이팅
             </p>
-            <hr className="w-full  border-[0.188rem] border-[#E9E9E9] mt-5 mb-5" />
+            <hr className="w-full border-[0.188rem] border-[#E9E9E9] mt-5 mb-5" />
             <div className="flex flex-col space-y-5">
-              <p className="text-base font-bold">스터디 목적</p>
-              <p className="text-base font-bold">스타일</p>
-              <p className="text-base font-bold">스터디 기간</p>
-              <p className="text-base font-bold">스터디 경험</p>
-              <p className="text-[#82829B]">
-                &#035; 성실함이 보이는 기록이에요
-              </p>
+              <div>
+                <p className="text-base font-bold">스터디 목적</p>
+              </div>
+              <div>
+                <p className="text-base font-bold">스타일</p>
+              </div>
+              <div>
+                <p className="text-base font-bold">스터디 기간</p>
+              </div>
+              <div>
+                <p className="text-base font-bold">스터디 경험</p>
+                <p className="text-[#82829B]">
+                  &#035; 성실함이 보이는 기록이에요
+                </p>
+                <div className="flex flex-row gap-3">
+                  {StudyExperienceDatas.map((study, index) => (
+                    <StudyExperienceCard
+                      key={index}
+                      title={study.title}
+                      score={study.score}
+                      attendance={study.attendance}
+                    />
+                  ))}
+                </div>
+              </div>
             </div>
           </div>
 

--- a/src/app/public-profile/page.tsx
+++ b/src/app/public-profile/page.tsx
@@ -3,6 +3,7 @@
 import Avartar from '@/components/common/Avatar';
 import Button from '@/components/common/Button';
 import StudyExperienceCard from '@/components/common/StudyExperienceCard';
+import TagList from '@/components/common/TagList';
 
 const handleAccept = () => {};
 
@@ -19,15 +20,34 @@ const PublicProfile = () => {
       score: 80,
       attendance: 100,
     },
+  ];
+
+  const StudyStyleDatas = [
     {
-      title: '피그마 중급 스터디',
-      score: 70,
-      attendance: 90,
+      style: '툴 능력 향상',
+    },
+    {
+      style: '해당 분야의 네트워크 확장',
+    },
+  ];
+
+  const StudyPurposeDatas = [
+    {
+      purpose: '손이 빠름',
+    },
+    {
+      purpose: '해당 네트워크 확장',
+    },
+  ];
+
+  const StudyPeriodDatas = [
+    {
+      period: '1개월 ~ 3개월',
     },
   ];
   return (
     <>
-      <div className="flex justify-center items-center  h-screen">
+      <div className="flex justify-center items-center h-auto">
         <div className="flex items-center flex-col w-[21.438rem] space-y-5">
           <div className="text-center space-y-5 ">
             <div className="font-bold text-[1.125rem]">오픈 프로필</div>
@@ -47,20 +67,36 @@ const PublicProfile = () => {
             <hr className="w-full border-[0.188rem] border-[#E9E9E9] mt-5 mb-5" />
             <div className="flex flex-col space-y-5">
               <div>
-                <p className="text-base font-bold">스터디 목적</p>
+                <p className="text-base font-bold">스타일</p>
+                <div className="flex flex-row gap-2">
+                  {StudyStyleDatas.map((style, index) => (
+                    <TagList key={index} tagData={[style.style]} disabled />
+                  ))}
+                </div>
               </div>
               <div>
-                <p className="text-base font-bold">스타일</p>
+                <p className=" text-base font-bold">스터디 목적</p>
+                <div className="flex flex-row gap-2">
+                  {StudyPurposeDatas.map((purpose, index) => (
+                    <TagList key={index} tagData={[purpose.purpose]} disabled />
+                  ))}
+                </div>
               </div>
               <div>
                 <p className="text-base font-bold">스터디 기간</p>
+                <div className="flex flex-row gap-2">
+                  {StudyPeriodDatas.map((period, index) => (
+                    <TagList key={index} tagData={[period.period]} disabled />
+                  ))}
+                </div>
               </div>
               <div>
                 <p className="text-base font-bold">스터디 경험</p>
                 <p className="text-[#82829B]">
                   &#035; 성실함이 보이는 기록이에요
                 </p>
-                <div className="flex flex-row gap-3">
+
+                <div className="flex flex-row p-5 gap-3">
                   {StudyExperienceDatas.map((study, index) => (
                     <StudyExperienceCard
                       key={index}

--- a/src/app/public-profile/page.tsx
+++ b/src/app/public-profile/page.tsx
@@ -77,9 +77,9 @@ const PublicProfile = () => {
               <Avartar size={'100%'} />
             </div>
           </div>
-          <div>
+          <div className="text-center">
             <div className="font-semibold text-[1.25rem]">제이크</div>
-            <p className=" text-[0.875rem]">기획자</p>
+            <p className=" text-[0.875rem] ">기획자</p>
           </div>
 
           <div>

--- a/src/app/public-profile/page.tsx
+++ b/src/app/public-profile/page.tsx
@@ -5,8 +5,6 @@ import Button from '@/components/common/Button';
 import StudyExperienceCard from '@/components/common/StudyExperienceCard';
 import TagList from '@/components/common/TagList';
 
-const handleAccept = () => {};
-
 const PublicProfile = () => {
   const StudyExperienceDatas = [
     {
@@ -45,16 +43,42 @@ const PublicProfile = () => {
       period: '1개월 ~ 3개월',
     },
   ];
+
+  const handleLeftClick = () => {};
+  const handleAccept = () => {};
   return (
     <>
-      <div className="flex justify-center items-center h-auto">
+      <div className="flex justify-center items-center h-auto ">
         <div className="flex items-center flex-col w-[21.438rem] space-y-5">
-          <div className="text-center space-y-5 ">
-            <div className="font-bold text-[1.125rem]">오픈 프로필</div>
-            <Avartar size={100} />
+          <div className="relative text-center space-y-5 ">
+            <div className="sticky top-0 flex items-center justify-center">
+              {/* 이전 단계로 이동 */}
+              <button onClick={handleLeftClick} className="fixed left-0">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="cursor-pointer">
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M15.5303 3.96967C15.8232 4.26256 15.8232 4.73744 15.5303 5.03033L8.56066 12L15.5303 18.9697C15.8232 19.2626 15.8232 19.7374 15.5303 20.0303C15.2374 20.3232 14.7626 20.3232 14.4697 20.0303L6.96967 12.5303C6.67678 12.2374 6.67678 11.7626 6.96967 11.4697L14.4697 3.96967C14.7626 3.67678 15.2374 3.67678 15.5303 3.96967Z"
+                    fill="black"
+                    fill-opacity="0.8"
+                  />
+                </svg>
+              </button>
+
+              <div className="font-bold text-lg mx-auto">오픈 프로필</div>
+            </div>
+            <div className="w-[6.25rem] h-[6.25rem] p-0 border-2 border-[#EADCF3] rounded-full">
+              <Avartar size={'100%'} />
+            </div>
           </div>
           <div>
-            <div className="font-semibold text-[1.25rem]">이름</div>
+            <div className="font-semibold text-[1.25rem]">제이크</div>
             <p className=" text-[0.875rem]">기획자</p>
           </div>
 

--- a/src/app/public-profile/page.tsx
+++ b/src/app/public-profile/page.tsx
@@ -19,22 +19,24 @@ const PublicProfile = () => {
       attendance: 100,
     },
   ];
-
-  const StudyStyleDatas = [
+  const StudyPurposeDatas = [
     {
-      style: '툴 능력 향상',
+      purpose: '툴 능력 향상',
     },
     {
-      style: '해당 분야의 네트워크 확장',
+      purpose: '해당 분야의 네트워킹 확장',
     },
   ];
 
-  const StudyPurposeDatas = [
+  const StudyStyleDatas = [
     {
-      purpose: '손이 빠름',
+      style: '손이 빠름',
     },
     {
-      purpose: '해당 네트워크 확장',
+      style: '열정적',
+    },
+    {
+      style: '동기부여가 필요한',
     },
   ];
 
@@ -91,14 +93,6 @@ const PublicProfile = () => {
             <hr className="w-full border-[0.188rem] border-[#E9E9E9] mt-5 mb-5" />
             <div className="flex flex-col space-y-5">
               <div>
-                <p className="text-base font-bold">스타일</p>
-                <div className="flex flex-row gap-2">
-                  {StudyStyleDatas.map((style, index) => (
-                    <TagList key={index} tagData={[style.style]} disabled />
-                  ))}
-                </div>
-              </div>
-              <div>
                 <p className=" text-base font-bold">스터디 목적</p>
                 <div className="flex flex-row gap-2">
                   {StudyPurposeDatas.map((purpose, index) => (
@@ -106,6 +100,15 @@ const PublicProfile = () => {
                   ))}
                 </div>
               </div>
+              <div>
+                <p className="text-base font-bold">스타일</p>
+                <div className="flex flex-row gap-2">
+                  {StudyStyleDatas.map((style, index) => (
+                    <TagList key={index} tagData={[style.style]} disabled />
+                  ))}
+                </div>
+              </div>
+
               <div>
                 <p className="text-base font-bold">스터디 기간</p>
                 <div className="flex flex-row gap-2">

--- a/src/app/public-profile/page.tsx
+++ b/src/app/public-profile/page.tsx
@@ -4,7 +4,7 @@ import Button from '@/components/common/Button';
 
 const handleAccept = () => {};
 
-const page = () => {
+const PublicProfile = () => {
   return (
     <>
       <div className="flex justify-center items-center  h-screen">
@@ -57,4 +57,4 @@ const page = () => {
     </>
   );
 };
-export default page;
+export default PublicProfile;

--- a/src/app/public_profile/page.tsx
+++ b/src/app/public_profile/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import Button from '@/components/common/Button';
+
+const handleAccept = () => {};
+
+const page = () => {
+  return (
+    <>
+      <div className="flex justify-center items-center  h-screen">
+        <div className="flex items-center flex-col w-[21.438rem] space-y-5">
+          <div className="text-center space-y-5 ">
+            <div className="font-bold text-[1.125rem]  ">오픈 프로필</div>
+            <img src="/images/profile.png" alt="프로필 " />
+          </div>
+          <div>
+            <div className="font-semibold text-[1.25rem]">이름</div>
+            <p className=" text-[0.875rem]">기획자</p>
+          </div>
+
+          <div>
+            <div className="font-bold">한줄 자기소개</div>
+            <p>
+              안녕하세요. 개발 관련 글을 꾸준히 쓰고 싶은데 의지가 부족해 스터디
+              버디들을 구하고 싶습니다 화이팅
+            </p>
+            <hr className="w-full  border-[0.188rem] border-[#E9E9E9] mt-5 mb-5" />
+            <div className="flex flex-col space-y-5">
+              <p className="text-base font-bold">스터디 목적</p>
+              <p className="text-base font-bold">스타일</p>
+              <p className="text-base font-bold">스터디 기간</p>
+              <p className="text-base font-bold">스터디 경험</p>
+              <p className="text-[#82829B]">
+                &#035; 성실함이 보이는 기록이에요
+              </p>
+            </div>
+          </div>
+
+          <div className="box-border flex flex-row gap-2 w-full ">
+            <span>
+              <p className="text-[#82829B]">수락가능인원</p>
+              <div className="flex">
+                <p className="text-primary">2명</p>
+                <p>/ 4명</p>
+              </div>
+            </span>
+
+            <Button
+              label="수락하기"
+              onClick={handleAccept}
+              bgColor="bg-[#804CFF]"
+              className="w-[15rem] h-[3.063rem]"
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+export default page;

--- a/src/components/common/StudyExperienceCard.tsx
+++ b/src/components/common/StudyExperienceCard.tsx
@@ -1,0 +1,26 @@
+interface StudyExperienceCardProps {
+  title: string;
+  score: number;
+  attendance: number;
+}
+
+const StudyExperienceCard = ({
+  title,
+  score,
+  attendance,
+}: StudyExperienceCardProps) => {
+  return (
+    <>
+      <div className="w-[10.313rem] h-[10.313rem] text-lg p-4 border-2 border-[#3F3FFF] rounded-lg flex flex-col">
+        <p className="w-[5.438rem] font-bold mb-2">{title}</p>
+        <div className="flex flex-row gap-1 w-[6.5rem] h-[1.5rem] justify-center items-center text-[0.813rem] bg-[#9470ED] text-white rounded-lg mb-5">
+          <p className="font-semibold">만족 점수</p>
+          <p className="font-normal">{score}점</p>
+        </div>
+
+        <p className="text-[#9470ED] text-sm">#출석률 {attendance}%</p>
+      </div>
+    </>
+  );
+};
+export default StudyExperienceCard;

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -2,13 +2,15 @@ interface tagProps {
   label: string;
   selected: boolean;
   onClick: () => void;
+  disabled?: boolean;
 }
 
-const Tag = ({ label, selected, onClick }: tagProps) => {
+const Tag = ({ label, selected, onClick, disabled }: tagProps) => {
   return (
     <button
       className={`w-auto h-[2.5rem] cursor-pointer box-border border-2 rounded-lg px-2 ${selected ? 'bg-primaryHover text-primary border-primary' : '*:bg-grey text-black border-greyBorder'} `}
-      onClick={onClick}>
+      onClick={!disabled ? onClick : undefined}
+      disabled={disabled}>
       {label}
     </button>
   );

--- a/src/components/common/TagList.tsx
+++ b/src/components/common/TagList.tsx
@@ -8,6 +8,7 @@ interface TagListProps {
   tagData: string[];
   onTagSelect?: (selectedTag: string[]) => void;
   className?: string;
+  disabled?: boolean;
 }
 
 /**
@@ -21,7 +22,12 @@ interface TagListProps {
  * @returns {JSX.Element} 렌더링된 TagList 컴포넌트.
  */
 
-const TagList = ({ tagData, onTagSelect, className }: TagListProps) => {
+const TagList = ({
+  tagData,
+  onTagSelect,
+  className,
+  disabled,
+}: TagListProps) => {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const handleTagClick = (label: string) => {
     const updatedTags = selectedTags.includes(label)
@@ -43,6 +49,7 @@ const TagList = ({ tagData, onTagSelect, className }: TagListProps) => {
           label={tag}
           selected={selectedTags.includes(tag)}
           onClick={() => handleTagClick(tag)}
+          disabled={disabled}
         />
       ))}
     </div>


### PR DESCRIPTION
## 🌱 만들고자 하는 기능
공개용 프로필 페이지 퍼블리싱 

## 🌱 구현 내용

- 스터디 경험에 들어가는 내용은 StudyExperienceCard 컴포넌트로 분리하여 적용
- TagList 컴포넌트에 disabled 추가해서 태그 재사용
- 기본 아바타 컴포넌트 사용

- 스와이퍼 적용 예정
- 태그에 들어가는 내용은 더미데이터로 우선 적용하였으나 이후 수정할 계획

![image](https://github.com/user-attachments/assets/2bbd530a-9dd4-4665-895f-36845218fb53)



- 오픈 프로필 왼쪽에 들어가는 left icon이 전체 화면에서는 나타나지만 정해진 너비 안으로 들어오지 않는 문제를 해결하지 못함
![image](https://github.com/user-attachments/assets/4860c93f-0491-4322-9b1a-4f2f2d641882)




## ✅ check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
