### PR TITLE
[✨feat]: 셀렉트 박스 바텀시트 컴포넌트

### DIFF
--- a/src/components/common/JobSelect.tsx
+++ b/src/components/common/JobSelect.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+
+interface JobSelectProps {
+  jobs: string[];
+}
+
+const JobSelect: React.FC<JobSelectProps> = ({ jobs }) => {
+  // isOpen: 바텀시트의 열림/닫힘 상태를 관리
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  // selectedJobs: 사용자가 선택한 직군들을 관리
+  const [selectedJobs, setSelectedJobs] = useState<string[]>([]);
+
+  // 바텀시트의 열림/닫힘을 토글하는 함수
+  const toggleBottomSheet = () => {
+    setIsOpen(!isOpen);
+  };
+
+  // 직군을 선택하거나 해제하는 함수
+  const handleJobSelect = (job: string) => {
+    setSelectedJobs((prev) =>
+      prev.includes(job) ? prev.filter((item) => item !== job) : [...prev, job],
+    );
+  };
+
+  return (
+    <div className="mb-4">
+      {/* 모집 직군 레이블 */}
+      <label className="block text-sm font-medium text-gray-700">
+        모집 직군
+      </label>
+
+      {/* 선택된 직군이 표시되는 입력란(클릭 시 바텀시트 열림) */}
+      <div
+        className="w-full h-[3rem] border-solid border-2 border-[#CED4DA] rounded-lg placeholder-[#82829B] p-[0.625rem] cursor-pointer"
+        onClick={toggleBottomSheet}>
+        {selectedJobs.length > 0 ? selectedJobs.join(', ') : '직군 선택'}
+      </div>
+
+      {/* 바텀시트: 열림 상태(isOpen)에 따라 표시 */}
+      {isOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-end z-50">
+          <div className="w-full max-w-md bg-white rounded-t-lg p-4">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-lg font-semibold">직군 선택</h2>
+              {/* 닫기 버튼: 바텀시트 닫기 */}
+              <button onClick={toggleBottomSheet} className="text-red-500">
+                닫기
+              </button>
+            </div>
+
+            {/* 직군 목록 */}
+            <ul className="space-y-2">
+              {jobs.map((job) => (
+                <li
+                  key={job}
+                  className="cursor-pointer"
+                  onClick={() => handleJobSelect(job)}>
+                  <span
+                    className={`p-2 block hover:bg-[#F0F0F0] ${
+                      selectedJobs.includes(job)
+                        ? ' text-[#6224FD]'
+                        : ' text-black'
+                    }`}>
+                    {job}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default JobSelect;


### PR DESCRIPTION
## 🌱 만들고자 하는 기능
![image](https://github.com/user-attachments/assets/cf66644c-edaf-4c18-8728-d5a408eccec2)


## 🌱 구현 내용
- JobSelect 컴포넌트: 입력필드 클릭시 사용자가 직군을 선택할 수 있는 바텀시트가 나옵니다.
- 사용자는 여러 직군을 선택할 수 있으며, 선택된 직군은 상단 입력 필드에 표시됩니다.
- UI: 선택된 직군은 텍스트에 보라색이 적용되고, 호버시 배경이 연그레이 색상이 됩니다
- `toggleBottomSheet` 바텀시트의 열림/닫힘 상태를 토글하는 기능을 구현했습니다.
- `handleJobSelect` 직군을 선택하거나 해제할 수 있는 로직을 구현했습니다.

사용예
```
 // 사용할 직군 목록
  const jobOptions = ['기획자', '디자이너', '개발자', '마케터', '데이터 분석가'];

 <JobSelect jobs={jobOptions} />
```
직군 목록 설정 (jobOptions)
- 사용 가능한 직군 옵션을 배열로 정의합니다. 이 배열은 JobSelect 컴포넌트의 jobs prop으로 전달됩니다.


## ✅ check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
