### PR TITLE
[🎨style] 스터디룸 생성 페이지 디자인 수정, 셀렉트 컴포넌트 모달 형식으로 변경

### DIFF
--- a/src/app/createstudy/page.tsx
+++ b/src/app/createstudy/page.tsx
@@ -45,9 +45,9 @@ const CreateStudyPage = () => {
   };
 
   return (
-    <div className="max-w-2xl mx-auto p-4 mb-20">
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-        <div>
+    <div className="max-w-2xl mx-auto py-4">
+      <form onSubmit={handleSubmit(onSubmit)} className=" space-y-6">
+        <div className="px-4">
           <label className="text-sm font-medium text-gray-700 mb-1">
             모집 직군
           </label>
@@ -66,7 +66,7 @@ const CreateStudyPage = () => {
           rules={{ required: '주제를 입력하세요' }}
           defaultValue=""
           render={({ field: { ref, ...restField } }) => (
-            <div>
+            <div className="px-4">
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 주제
               </label>
@@ -92,7 +92,7 @@ const CreateStudyPage = () => {
           rules={{ required: '목표를 입력하세요' }}
           defaultValue=""
           render={({ field: { ref, ...restField } }) => (
-            <div>
+            <div className="px-4">
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 목표
               </label>
@@ -117,7 +117,7 @@ const CreateStudyPage = () => {
           control={control}
           defaultValue=""
           render={({ field: { ref, ...restField } }) => (
-            <div>
+            <div className="px-4">
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 소개
               </label>
@@ -139,7 +139,7 @@ const CreateStudyPage = () => {
           control={control}
           defaultValue=""
           render={({ field: { ref, ...restField } }) => (
-            <div>
+            <div className="px-4">
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 진행방식과 커리큘럼
               </label>
@@ -156,7 +156,7 @@ const CreateStudyPage = () => {
           )}
         />
 
-        <div className="flex gap-[12px]">
+        <div className="flex gap-[12px] px-4">
           <Controller
             name="startDate"
             control={control}
@@ -176,7 +176,7 @@ const CreateStudyPage = () => {
             control={control}
             defaultValue=""
             render={({ field }) => (
-              <div className="flex flex-col flex-auto">
+              <div className="flex flex-col flex-auto ">
                 <label className="text-sm font-medium text-gray-700 mb-1">
                   종료일
                 </label>
@@ -191,7 +191,7 @@ const CreateStudyPage = () => {
           control={control}
           defaultValue=""
           render={({ field }) => (
-            <div>
+            <div className="px-4">
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 정기적 모임
               </label>
@@ -210,7 +210,7 @@ const CreateStudyPage = () => {
           control={control}
           defaultValue={1}
           render={({ field }) => (
-            <div>
+            <div className="px-4">
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 스터디 모집 인원
               </label>
@@ -224,7 +224,7 @@ const CreateStudyPage = () => {
           control={control}
           defaultValue=""
           render={({ field }) => (
-            <div>
+            <div className="px-4">
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 관련 태그
               </label>

--- a/src/app/createstudy/page.tsx
+++ b/src/app/createstudy/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
+import Button from '@/components/common/Button';
 import CountInput from '@/components/common/CountInput';
 import { Input } from '@/components/common/Input';
 import MultiSelect from '@/components/common/MultiSelect';
@@ -47,7 +48,7 @@ const CreateStudyPage = () => {
     <div className="max-w-2xl mx-auto p-4 mb-20">
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="text-sm font-medium text-gray-700 mb-1">
             모집 직군
           </label>
           <MultiSelect
@@ -122,6 +123,7 @@ const CreateStudyPage = () => {
               </label>
               <CountInput
                 inputType="textarea"
+                className="resize-none"
                 placeholder="소개 내용을 입력하세요"
                 maxCount={200}
                 rows={4}
@@ -143,6 +145,7 @@ const CreateStudyPage = () => {
               </label>
               <CountInput
                 inputType="textarea"
+                className="resize-none"
                 placeholder="스터디를 설명해주세요"
                 maxCount={500}
                 rows={6}
@@ -153,17 +156,17 @@ const CreateStudyPage = () => {
           )}
         />
 
-        <div className="flex">
+        <div className="flex gap-[12px]">
           <Controller
             name="startDate"
             control={control}
             defaultValue=""
             render={({ field }) => (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+              <div className="flex flex-col flex-auto">
+                <label className="text-sm font-medium text-gray-700 mb-1">
                   시작일
                 </label>
-                <Input type="date" {...field} />
+                <Input className="w-full" type="date" {...field} />
               </div>
             )}
           />
@@ -173,11 +176,11 @@ const CreateStudyPage = () => {
             control={control}
             defaultValue=""
             render={({ field }) => (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+              <div className="flex flex-col flex-auto">
+                <label className="text-sm font-medium text-gray-700 mb-1">
                   종료일
                 </label>
-                <Input type="date" {...field} />
+                <Input className="w-full" type="date" {...field} />
               </div>
             )}
           />
@@ -193,6 +196,7 @@ const CreateStudyPage = () => {
                 정기적 모임
               </label>
               <Input
+                className="w-full"
                 type="text"
                 placeholder="예: 매주 수요일 20시"
                 {...field}
@@ -210,7 +214,7 @@ const CreateStudyPage = () => {
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 스터디 모집 인원
               </label>
-              <Input type="number" {...field} />
+              <Input className="w-full" type="number" {...field} />
             </div>
           )}
         />
@@ -224,22 +228,30 @@ const CreateStudyPage = () => {
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 관련 태그
               </label>
-              <Input type="text" placeholder="태그를 입력하세요" {...field} />
+              <Input
+                className="w-full"
+                type="text"
+                placeholder="태그를 입력하세요"
+                {...field}
+              />
             </div>
           )}
         />
+        <div className="flex gap-[13px] sticky bottom-[62px] left-1/2 w-full max-w-2xl bg-white/10 backdrop-blur-sm p-4 border-t border-[#CCCEF0]">
+          <Button
+            label="이전"
+            bgColor="bg-white"
+            textColor="text-[#CED4DA]"
+            className="w-1/3 h-[3.063rem] border-2
+          "
+            onClick={() => console.log('이전 버튼 클릭됨')}
+          />
 
-        <div className="flex justify-between">
-          <button
-            type="button"
-            className="px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50">
-            이전
-          </button>
-          <button
-            type="submit"
-            className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700">
-            내용작성 완료
-          </button>
+          <Button
+            label="작성완료"
+            onClick={() => console.log('다음 버튼 클릭됨')}
+            className="w-2/3 h-[3.063rem]"
+          />
         </div>
       </form>
     </div>

--- a/src/app/createstudy/page.tsx
+++ b/src/app/createstudy/page.tsx
@@ -46,7 +46,7 @@ const CreateStudyPage = () => {
 
   return (
     <div className="max-w-2xl mx-auto py-4">
-      <form onSubmit={handleSubmit(onSubmit)} className=" space-y-6">
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
         <div className="px-4">
           <label className="text-sm font-medium text-gray-700 mb-1">
             모집 직군
@@ -156,7 +156,7 @@ const CreateStudyPage = () => {
           )}
         />
 
-        <div className="flex gap-[12px] px-4">
+        <div className="flex gap-3 px-4">
           <Controller
             name="startDate"
             control={control}
@@ -176,7 +176,7 @@ const CreateStudyPage = () => {
             control={control}
             defaultValue=""
             render={({ field }) => (
-              <div className="flex flex-col flex-auto ">
+              <div className="flex flex-col flex-auto">
                 <label className="text-sm font-medium text-gray-700 mb-1">
                   종료일
                 </label>
@@ -237,20 +237,19 @@ const CreateStudyPage = () => {
             </div>
           )}
         />
-        <div className="flex gap-[13px] sticky bottom-[62px] left-1/2 w-full max-w-2xl bg-white/10 backdrop-blur-sm p-4 border-t border-[#CCCEF0]">
+        <div className="flex gap-3 sticky bottom-[62px] left-1/2 w-full max-w-2xl bg-white/10 backdrop-blur-sm p-4 border-t border-[#CCCEF0]">
           <Button
             label="이전"
             bgColor="bg-white"
             textColor="text-[#CED4DA]"
-            className="w-1/3 h-[3.063rem] border-2
-          "
+            className="w-1/3 h-12 border-2"
             onClick={() => console.log('이전 버튼 클릭됨')}
           />
 
           <Button
             label="작성완료"
             onClick={() => console.log('다음 버튼 클릭됨')}
-            className="w-2/3 h-[3.063rem]"
+            className="w-2/3 h-12"
           />
         </div>
       </form>

--- a/src/components/common/MultiSelect.tsx
+++ b/src/components/common/MultiSelect.tsx
@@ -49,8 +49,8 @@ const MultiSelect = ({
       </div>
 
       {isOpen && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-end z-50">
-          <div className="w-full max-w-md bg-white rounded-t-lg p-4">
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
+          <div className="w-[90%] max-w-md bg-white rounded-lg p-4">
             <div className="flex justify-between items-center mb-4">
               <h2 className="text-lg font-semibold">{title}</h2>
               <button onClick={toggleBottomSheet} className="text-red-500">


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

## 🌱 구현 내용

https://github.com/user-attachments/assets/89ffdd2b-4e8d-4905-b3a3-7929fcefe66f

- MultiSelect 컴포넌트를 기존의 바텀시트에서 모달 형식으로 변경했습니다.
- 스터디 생성 페이지 디자인을 수정했습니다.
  - 하단 버튼 고정: 하단 버튼 영역을 sticky로 변경하여 사용자의 스크롤에 따라 버튼이 항상 보이도록 했습니다.

## ✅ check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
