### PR TITLE
 [✨feat]: CommonHeader 구현 및 페이지 적용

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,18 +1,10 @@
 'use client';
-<<<<<<< HEAD
 
-import { useForm } from 'react-hook-form';
-
-import Input from '@/components/common/Input';
-import Image from 'next/image';
-
-=======
 import Image from 'next/image';
 import Link from 'next/link';
 
 import { useForm } from 'react-hook-form';
 
->>>>>>> 7b75d1ccc30da3fd1d423ba0455bb4ba81f51d27
 import Button from '@/components/common/Button';
 import { Input } from '@/components/common/Input';
 

--- a/src/app/manage-studyroom/page.tsx
+++ b/src/app/manage-studyroom/page.tsx
@@ -1,12 +1,11 @@
+import CommonHeader from '@/components/common/CommonHeader';
 import React from 'react';
 
 const Page = () => {
   return (
     <div className="w-full px-[.9375rem] pt-11 pb-20 min-h-screen bg-[#F6F6F6]">
       {/* Gnb 라우팅 테스트 위해 임의로 넣어놓은 컨텐츠입니다. */}
-      <header className="h-10 flex items-center mb-[.6875rem]">
-        <p className="text-lg text-[#212529] font-bold">스터디룸 관리</p>
-      </header>
+      <CommonHeader title="스터디룸 관리" />
     </div>
   );
 };

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -6,6 +6,7 @@ import Button from '@/components/common/Button';
 import ImageUploader from '@/components/common/ImageUploader';
 import ToggleSwitch from '@/components/common/ToggleSwitch';
 import UserStatusSummary from '@/components/common/UserStatusSummary';
+import CommonHeader from '@/components/common/CommonHeader';
 
 const Page = () => {
   const router = useRouter();
@@ -42,9 +43,7 @@ const Page = () => {
   return (
     <div className="min-h-screen ">
       <div className="w-full px-[.9375rem] pt-11 pb-20">
-        <header className="h-10 flex items-center mb-[.6875rem]">
-          <p className="text-lg text-[#212529] font-bold">마이페이지</p>
-        </header>
+        <CommonHeader title="마이페이지" />
         <div className="flex flex-col gap-5">
           <div className="flex flex-row gap-5">
             <button>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -9,6 +9,7 @@ import ToggleSwitch from '@/components/common/ToggleSwitch';
 
 import Filter from '../../../public/images/Filter.svg';
 import MagnifyingGlass from '../../../public/images/MagnifyingGlass.svg';
+import CommonHeader from '@/components/common/CommonHeader';
 
 const searchResults: StudyroomCardProps[] = [
   {
@@ -119,9 +120,7 @@ const Page = () => {
     <div className="w-full min-h-screen bg-[#F6F6F6]">
       <div className="w-full px-[.9375rem] pt-11 pb-6 bg-white">
         {/* Contents */}
-        <header className="h-10 flex items-center mb-[.6875rem] text-lg text-[#212529] font-bold">
-          탐색하기
-        </header>
+        <CommonHeader title="탐색하기" />
 
         <div className="relative">
           <span className="absolute inset-y-0 left-0 flex items-center pl-[14px]">

--- a/src/app/studyroom/page.tsx
+++ b/src/app/studyroom/page.tsx
@@ -9,6 +9,7 @@ import StudyroomCard, {
 import WavingHand from '../../../public/images//Waving_hand.svg';
 import Question from '../../../public/images/Question.svg';
 import ThinkingFace from '../../../public/images/Thinking_face.svg';
+import CommonHeader from '@/components/common/CommonHeader';
 
 const StudyroomCardItems: StudyroomCardProps[] = [
   {
@@ -60,16 +61,11 @@ const Page = () => {
 
   return (
     <div className="min-h-screen bg-[#F6F6F6] w-full px-[.9375rem] pt-11 pb-20">
-      <header className="h-10 flex items-center mb-[.6875rem]">
-        <div className="w-1/2">
-          <p className="text-lg text-[#212529] font-bold">스터디룸</p>
-        </div>
-        <div className="w-1/2 flex justify-end">
-          {/* TODO) 참여 스터디룸 존재 여부에 따라 아이콘 조건부 렌더링 구현 (없으면 ?, 있으면 +) */}
-          <Question />
-        </div>
-      </header>
-
+      <div className="flex flex-row justify-between">
+        <CommonHeader title="스터디룸" />
+        {/* TODO) 참여 스터디룸 존재 여부에 따라 아이콘 조건부 렌더링 구현 (없으면 ?, 있으면 +) */}
+        <img src="/images/Question.svg" alt="question" />
+      </div>
       {/* TODO) 참여 스터디룸 존재시 아래 요소 전체 렌더링 X */}
       <div>
         <p className="text-lg text-[#212529] font-bold mb-2">

--- a/src/components/common/CommonHeader.tsx
+++ b/src/components/common/CommonHeader.tsx
@@ -1,0 +1,12 @@
+interface HeaderProps {
+  title: string;
+}
+
+const CommonHeader = ({ title }: HeaderProps) => {
+  return (
+    <header className="h-10 flex items-center mb-[.6875rem] text-lg text-[#212529] font-bold">
+      {title}
+    </header>
+  );
+};
+export default CommonHeader;


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

공통으로 사용되는 header를 컴포넌트로 분리 후 적용

## 🌱 구현 내용

-CommonHeader 컴포넌트 생성
-스터디룸, 탐색하기, 스터디룸 관리, 마이페이지에 적용

![image](https://github.com/user-attachments/assets/2b95a6fa-5ab6-48c3-a335-5992d8ccc44f)
![image](https://github.com/user-attachments/assets/d98e3b53-1c7b-4c19-b718-2a812a0dad78)
![image](https://github.com/user-attachments/assets/3fb5b651-8e82-4e0b-9214-3bdcbbc285b1)
![image](https://github.com/user-attachments/assets/dd13ca70-3949-4a2e-8f16-736fd58627b8)


## ✅ check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
